### PR TITLE
Fix BUG 'Syntax node is not within syntax tree'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # 2021NETConf_SourceGenerator
+
+视频地址:
+
+[https://www.bilibili.com/video/BV1CZ4y1Q7oK](https://www.bilibili.com/video/BV1CZ4y1Q7oK)


### PR DESCRIPTION
The 'FindTypeSymbol' function will throw 'Syntax node is not within syntax tree' when 'BaseTypeDeclarationSyntax'(IMapper) isn't the first on syntaxtrees .

This req added 'syntaxTree.GetRoot().DescendantNodes().Any(x => x.IsKind(SyntaxKind.SimpleBaseType))' to fix bug.

😁
yangzhongke‘s fan